### PR TITLE
cast Uint8Array to Array in IE11

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -12,7 +12,7 @@ const tinygen = (len=16) => {
   var arr = new Uint8Array(len)
   crypto.getRandomValues(arr)
   // IE11 Uint8Array does not have `reduce` so we cast to Array
-  if (!arr.reduce) arr = [].slice.call(arr)
+  if (typeof arr.reduce !== 'function') arr = [].slice.call(arr)
   return arr.reduce((id, x) => id + chars[x % 64], '')
 }
 


### PR DESCRIPTION
![11](http://www.triella.com/wp-content/uploads/2015/12/IE2.png)

IE11 `Uint8Array` does not provide a `reduce` function, this checks to see if a `reduce` function exists and if not casts to an `Array`.