### PR TITLE
Add MIT license to allow open sourcing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright 2016 Articulate Global, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tinygen [![npm version](https://img.shields.io/npm/v/@articulate/tinygen.svg)](https://www.npmjs.com/package/@articulate/tinygen) [![npm version](https://img.shields.io/npm/dt/@articulate/tinygen.svg)](https://www.npmjs.com/package/@articulate/tinygen)
+# tinygen [![npm version](https://img.shields.io/npm/v/@articulate/tinygen.svg)](https://www.npmjs.com/package/@articulate/tinygen)
 
 Tiniest of tiny `base64` uid generators.  Teeny-tiny browser version included, only 624 bytes.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "dist/browser.js",
   "repository": "git@github.com:articulate/tinygen.git",
   "author": "articulate",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "build": "buble -i src -o dist",
     "clean": "rm -rf dist && mkdir -p dist",


### PR DESCRIPTION
![open source](http://aspira.ie/wp-content/uploads/2016/08/bartopen_source_10932.jpg)

Looks like the responsible thing to do before converting this project to `public` was to add a license, so I blatantly plagiarized the one we use elsewhere, and also marked the change in the `package.json`.  No testing required this time.  Just need a general consensus that this is an 🆗 thing to do.

ping @cdwills @fromonesrc  